### PR TITLE
Fix bug with SessionReducer

### DIFF
--- a/frontend/components/session_form.jsx
+++ b/frontend/components/session_form.jsx
@@ -25,6 +25,7 @@ class SessionForm extends React.Component {
   }
 
   handleSubmit(e) {
+    console.log('handling submit');
     e.preventDefault;
     
     /* remove the temporary piece of state to track email_or_user */

--- a/frontend/reducers/session_reducer.js
+++ b/frontend/reducers/session_reducer.js
@@ -20,8 +20,7 @@ const SessionReducer = (state = _nullSession, action) => {
     case LOGOUT_CURRENT_USER:
       return { currentUserId: null };
     default: 
-      return _nullSession;
-
+      return state;
   }
 }
 


### PR DESCRIPTION
## Update
* Found a bug in the Session Reducer whereby it was defaulting the currentUser slice of state to a nullSession input when the state updates after RECEIVING_SONGS. Changing the default action to return state resolved the issue.
* Updated seed file with the demo user's account. 

## More Todo
* Render login errors.