### PR TITLE
Song page lyrics and annotations

### DIFF
--- a/app/assets/stylesheets/api/annotations.scss
+++ b/app/assets/stylesheets/api/annotations.scss
@@ -1,3 +1,57 @@
 // Place all the styles related to the api/annotations controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.song-page-detail-annotation {
+  min-width: 40%;
+
+  position: relative;
+  width: 400px;
+}
+
+.song-page-annotation-title {
+
+  padding-bottom: 30px;
+}
+
+.song-page-annotation, .song-page-about {
+  line-height: 1.5em;
+}
+
+.song-page-annotation {
+
+  border-left: 3px solid #99A7EE;
+  background-color: white;
+  padding: 30px;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 4px 8px;
+  position: fixed;
+  top: 48vh;
+  width: 30vw;
+
+}
+
+.sizzle {
+  font-size: 25px;
+  font-weight: lighter;
+  line-height: 1em;
+  margin-bottom: 25px;
+  margin-top: 25px;
+  margin-left: 20px;
+  position: relative;
+}
+
+.icon {
+  top: -20px;
+  left: -20px;
+  font-size: 20px;
+  color: #99a7ee;
+  position: absolute;
+}
+
+.annotation-author {
+  margin-top: 20px;
+  font-size: 12px;
+  margin-bottom: 20px;
+
+}
+

--- a/app/assets/stylesheets/api/annotations.scss
+++ b/app/assets/stylesheets/api/annotations.scss
@@ -55,3 +55,9 @@
 
 }
 
+.header {
+  color: #9A9A9A;
+  font-size: 12px;
+  padding-bottom: 15px;
+  letter-spacing: .08em;
+}

--- a/app/assets/stylesheets/api/referents.scss
+++ b/app/assets/stylesheets/api/referents.scss
@@ -1,3 +1,35 @@
 // Place all the styles related to the api/referents controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+/* Song Lyrics styles */
+
+// .song-page-lyrics p {
+//   display: inline-block;
+// }
+
+.referent span {
+
+  background-color: #e9e9e9;
+  transition: all .15s linear;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  padding-left: 1px;
+  padding-right: 1px;
+
+}
+
+.referent:hover span {
+
+  cursor: pointer;
+  background-color: #FFFF64;
+
+}
+
+// .active span {
+//   background-color: #FFFF64;
+// }
+
+span.active-temp{
+  background-color: #FFFF64;
+}

--- a/app/assets/stylesheets/api/songs.scss
+++ b/app/assets/stylesheets/api/songs.scss
@@ -104,34 +104,10 @@ p.song-page-lyrics-title, .song-page-annotation-title {
   padding-bottom: 30px;
 }
 
-.song-page-annotation-about {
+.song-page-annotation {
   line-height: 1.5em;
 }
 
-/* Song Lyrics styles */
-
-// .song-page-lyrics p {
-//   display: inline-block;
-// }
-
-.referent span {
-
-  background-color: #e9e9e9;
-  transition: all .15s linear;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  padding-left: 1px;
-  padding-right: 1px;
-
-}
-
-.referent:hover span {
-
-  cursor: pointer;
-  background-color: #FFFF64;
-
-}
-
-.active span {
-  background-color: #FFFF64;
+p.active {
+  background-color: yellow;
 }

--- a/app/assets/stylesheets/api/songs.scss
+++ b/app/assets/stylesheets/api/songs.scss
@@ -48,11 +48,13 @@
   font-size: 24px;
   color: white;
   padding-bottom: 10px;
+  
 }
 
 .song-page-header-detail p {
   color: #9a9a9a;
-  font-size: 18px
+  font-size: 18px;
+  font-weight: lighter;
 }
 
 .song-page-detail {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -75,3 +75,12 @@ body {
 }
 
 
+::selection {
+    color: none;
+    background: none;
+}
+/* For Mozilla Firefox */
+::-moz-selection {
+    color: none;
+    background: none;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -77,7 +77,7 @@ body {
 
 ::selection {
     color: none;
-    background: none;
+    background: #FFFF64;
 }
 /* For Mozilla Firefox */
 ::-moz-selection {

--- a/app/controllers/api/referents_controller.rb
+++ b/app/controllers/api/referents_controller.rb
@@ -19,6 +19,19 @@ class Api::ReferentsController < ApplicationController
     end
   end
 
+  def destroy
+  
+    @referent = Referent.find_by(id: params[:referentId])
+    
+    if !@referent.nil?
+      @referent.destroy
+      render json: ['null']
+    else
+      render json: ['No referent by that id found', params[:referentId]], status: 422
+    end
+  
+  end
+
   private
   def referent_params
     params.require(:referent).permit(:fragment_range_start, :fragment_range_end, :song_id)

--- a/frontend/actions/referent_actions.js
+++ b/frontend/actions/referent_actions.js
@@ -2,7 +2,8 @@ import * as ReferentAPIUtil from '../util/referents_api_util';
 
 export const RECEIVE_REFERENTS = "RECEIVE_REFERENTS";
 export const RECEIVE_REFERENT = "RECEIVE_REFERENT";
-export const RECEIVE_REFERENT_ERRORS = "RECEIVE_REFERENT_ERRORS"
+export const RECEIVE_REFERENT_ERRORS = "RECEIVE_REFERENT_ERRORS";
+export const REMOVE_REFERENT = "REMOVE_REFERENT";
 
 /* action creators */
 
@@ -36,7 +37,20 @@ export const receiveReferentErrors = errors => {
   )
 }
 
+export const removeReferent = referentId => {
+  
+  return (
+
+    {
+      type: REMOVE_REFERENT,
+      referentId
+    }
+
+  )
+}
+
 /* thunk action creators */
+
 export const createReferent = referent => dispatch => ReferentAPIUtil.createReferent(referent)
   .then(
     referent => dispatch(receiveReferent(referent)),
@@ -49,3 +63,9 @@ export const fetchReferents = songId => dispatch => ReferentAPIUtil.fetchReferen
     response => dispatch(receiveReferentErrors(response.responseJSON))
   )
 
+export const deleteReferent = referentId => dispatch => ReferentAPIUtil.deleteReferent(referentId)
+  .then( 
+    () => dispatch(removeReferent(referentId)
+  )
+    
+  )

--- a/frontend/components/song_page.jsx
+++ b/frontend/components/song_page.jsx
@@ -9,13 +9,17 @@ class SongPage extends React.Component {
     super(props);
 
     this.state = {
+      
       activeAnnotationId: -1,
       annotationSizzle: '',
+      annotationFormActive: false
     }
+
     this.songPageLyricsRef = React.createRef();
-    this.setCurrAnnotation = this.setCurrAnnotation.bind(this);
+    this.setCurrAnnotationStatus = this.setCurrAnnotationStatus.bind(this);
 
   }
+
   componentDidMount() {
 
     const fetchSong = this.props.fetchSong(this.props.match.params.songId);
@@ -23,14 +27,18 @@ class SongPage extends React.Component {
     const fetchAnnots = this.props.fetchAnnotations(this.props.match.params.songId);
 
     Promise.all( [fetchSong, fetchRefs, fetchAnnots]);
+  
   }
 
-  setCurrAnnotation(id, sizzleText) {
+  setCurrAnnotationStatus(id, sizzleText, formActive) {
 
-    console.log(sizzleText);
+    this.setState({ 
+      activeAnnotationId: id, 
+      annotationSizzle: sizzleText, 
+      annotationFormActive: formActive
 
-    this.setState({ activeAnnotationId: id, annotationSizzle: sizzleText });
-  
+    });
+    
   }
 
   render() {
@@ -55,16 +63,17 @@ class SongPage extends React.Component {
                 lyrics={song.body} 
                 referents={referents} 
                 createReferent={createReferent}
-                setCurrAnnotation={this.setCurrAnnotation} />
+                setCurrAnnotationStatus={this.setCurrAnnotationStatus} />
             </div>
             <div className="song-page-detail-annotation">
               <SongPageAnnotation 
                 song={this.props.song}
                 annotations={this.props.annotations}
-                annotationSizzle={this.state.annotationSizzle}
                 createAnnotation={createAnnotation}
                 deleteAnnotation={deleteAnnotation}
                 activeAnnotationId={this.state.activeAnnotationId}
+                annotationSizzle={this.state.annotationSizzle}
+                annotationFormActive={this.state.annotationFormActive}
                 />
             </div>
           </div>

--- a/frontend/components/song_page.jsx
+++ b/frontend/components/song_page.jsx
@@ -10,8 +10,9 @@ class SongPage extends React.Component {
 
     this.state = {
       activeAnnotationId: -1,
+      annotationSizzle: '',
     }
-
+    this.songPageLyricsRef = React.createRef();
     this.setCurrAnnotation = this.setCurrAnnotation.bind(this);
 
   }
@@ -24,8 +25,12 @@ class SongPage extends React.Component {
     Promise.all( [fetchSong, fetchRefs, fetchAnnots]);
   }
 
-  setCurrAnnotation(id) {
-    this.setState({ activeAnnotationId: id }/* , () => console.log(this.state.activeAnnotationId) */);
+  setCurrAnnotation(id, sizzleText) {
+
+    console.log(sizzleText);
+
+    this.setState({ activeAnnotationId: id, annotationSizzle: sizzleText });
+  
   }
 
   render() {
@@ -41,10 +46,11 @@ class SongPage extends React.Component {
         
         <SongPageHeader song={this.props.song}/>
         
-        <div className="song-page-detail">
+        <div onClick={(e) => this.songPageLyricsRef.current.resetActiveRegion(e)} className="song-page-detail">
           <div className="song-page-detail-wrapper">
             <div>
               <SongPageLyrics 
+                ref={this.songPageLyricsRef}
                 song={song} 
                 lyrics={song.body} 
                 referents={referents} 
@@ -55,6 +61,7 @@ class SongPage extends React.Component {
               <SongPageAnnotation 
                 song={this.props.song}
                 annotations={this.props.annotations}
+                annotationSizzle={this.state.annotationSizzle}
                 createAnnotation={createAnnotation}
                 deleteAnnotation={deleteAnnotation}
                 activeAnnotationId={this.state.activeAnnotationId}

--- a/frontend/components/song_page_annotation.jsx
+++ b/frontend/components/song_page_annotation.jsx
@@ -1,40 +1,56 @@
 import React from 'react';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faQuoteRight, faQuoteLeft, faPortrait } from '@fortawesome/free-solid-svg-icons';
+// import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+// import { faQuoteLeft } from '@fortawesome/free-solid-svg-icons';
+
+import SongPageAnnotationDetail from './song_page_annotation_detail';
 
 class SongPageAnnotation extends React.Component {
 
   constructor(props) {
     super(props);
-
   }
 
   renderCurrentAnnotation() {
-
-    if (this.props.activeAnnotationId === -1) {
+    
+    if (this.props.activeAnnotationId === -1 && this.props.annotationFormActive === false) {  /* no active annotation or annotationForm*/
       return (
         <p className="song-page-about">
           {this.props.song.about}
         </p>
       )
-    } 
+    }
 
-    let annotationSizzleEnd = (!this.props.annotationSizzle.includes("?")) ? "..." : "";
+    return (  /* render form or annotation */
 
-    return (
-      <div className="annotation">
+      // <div className="annotation">
 
-        <div className="song-page-annotation">
-          <div className = "sizzle">
-            <FontAwesomeIcon className="icon" icon={faQuoteLeft} />
-            {this.props.annotationSizzle + annotationSizzleEnd}
-          </div>
-          {this.props.annotations[this.props.activeAnnotationId].body}
-          <p className="annotation-author">AuthorPlaceholder</p>
+      //   <div className="song-page-annotation">
+      //     <div className="header"><p>GENIUS ANNOTATION</p></div>
 
-        </div>
-      </div>
+      //     <div className = "sizzle">
+
+      //       <FontAwesomeIcon className="icon" icon={faQuoteLeft} />
+      //       {this.props.annotationSizzle + annotationSizzleEnd}
+
+      //     </div>
+
+      //     {this.props.annotations[this.props.activeAnnotationId].body}
+
+      //     <p className="annotation-author">AuthorPlaceholder</p>
+
+      //   </div>
+      // </div>
+
+      <SongPageAnnotationDetail
+
+        annotations={this.props.annotations}
+        activeAnnotationId={this.props.activeAnnotationId}
+        annotationFormActive={this.props.annotationFormActive}
+        annotationSizzle={this.props.annotationSizzle}
+  
+       />
+
     )
 
   }

--- a/frontend/components/song_page_annotation.jsx
+++ b/frontend/components/song_page_annotation.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuoteRight, faQuoteLeft, faPortrait } from '@fortawesome/free-solid-svg-icons';
+
 class SongPageAnnotation extends React.Component {
 
   constructor(props) {
@@ -7,21 +10,30 @@ class SongPageAnnotation extends React.Component {
 
   }
 
-
   renderCurrentAnnotation() {
 
     if (this.props.activeAnnotationId === -1) {
       return (
-        <p className="song-page-annotation-about">
+        <p className="song-page-about">
           {this.props.song.about}
         </p>
       )
     } 
+
+    let annotationSizzleEnd = (!this.props.annotationSizzle.includes("?")) ? "..." : "";
+
     return (
       <div className="annotation">
-        <p className="song-page-annotation-about">
+
+        <div className="song-page-annotation">
+          <div className = "sizzle">
+            <FontAwesomeIcon className="icon" icon={faQuoteLeft} />
+            {this.props.annotationSizzle + annotationSizzleEnd}
+          </div>
           {this.props.annotations[this.props.activeAnnotationId].body}
-        </p>
+          <p className="annotation-author">AuthorPlaceholder</p>
+
+        </div>
       </div>
     )
 
@@ -29,11 +41,11 @@ class SongPageAnnotation extends React.Component {
 
   render() {
 
-      if(this.props.annotations === undefined) {
-        return null;
-      }
+    if(this.props.annotations === undefined) {
+      return null;
+    }
 
-      return (
+    return (
       
       <div className="song-page-annotation-wrapper">
 

--- a/frontend/components/song_page_annotation_detail.jsx
+++ b/frontend/components/song_page_annotation_detail.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuoteLeft } from '@fortawesome/free-solid-svg-icons';
+
+const SongPageAnnotationDetail = (props) => {
+
+  let annotationSizzleEnd = (!props.annotationSizzle.includes("?")) ? "..." : "";
+
+
+  const renderAnnotationOrForm = () => {
+
+    if (props.activeAnnotationId !== -1) {
+      return (
+        <div>
+
+          <div className="sizzle">
+
+            <FontAwesomeIcon className="icon" icon={faQuoteLeft} />
+            {props.annotationSizzle + annotationSizzleEnd}
+
+          </div>
+
+          {props.annotations[props.activeAnnotationId].body}
+
+          <p className="annotation-author">AuthorPlaceholder</p>
+
+        </div>
+      )
+    }
+
+    if (props.annotationFormActive) {
+      return (
+
+        <div>
+          I am a new annotation form
+        </div>
+
+      )
+    } 
+
+  }
+
+  return (  /* render form or annotation */
+
+    <div className="annotation">
+
+      <div className="song-page-annotation">
+        <div className="header"><p>GENIUS ANNOTATION</p></div>
+
+        {/* <div className="sizzle">
+
+          <FontAwesomeIcon className="icon" icon={faQuoteLeft} />
+          {props.annotationSizzle + annotationSizzleEnd}
+
+        </div>
+
+        {props.annotations[props.activeAnnotationId].body}
+
+        <p className="annotation-author">AuthorPlaceholder</p> */}
+
+        { renderAnnotationOrForm() }
+
+      </div>
+    </div>
+
+  )
+
+
+}
+
+export default SongPageAnnotationDetail;

--- a/frontend/components/song_page_lyrics.jsx
+++ b/frontend/components/song_page_lyrics.jsx
@@ -12,14 +12,87 @@ class SongPageLyrics extends React.Component {
 
     this.reconcileReferentsToLyrics = this.reconcileReferentsToLyrics.bind(this);
     this.setCurrReferent = this.setCurrReferent.bind(this);
+    this.setActiveRegion = this.setActiveRegion.bind(this);
   }
+
+
+
+  setActiveRegion(e) {
+
+    /* get selection particulars */
+    let selection = window.getSelection();
+  
+    // console.log(selection);
+
+    let startEleId = selection.anchorNode.parentNode.id;
+    let endEleId = selection.focusNode.parentNode.id;
+
+    // console.log(startEleId);
+    // console.log(endEleId);
+
+    if (startEleId === "" || endEleId === "") {
+      return;
+    }
+
+    startEleId = parseInt(startEleId);
+    endEleId = parseInt(endEleId);
+
+    // console.log(startEleId);
+    // console.log(endEleId);
+
+    /* swap start and end if start is greater than end */
+    if (startEleId > endEleId) {
+      [ startEleId, endEleId ] = [ endEleId, startEleId]
+    }
+
+    /* get range of lines from start to end */
+    let range = _.range(startEleId, endEleId + 1);
+    console.log(range)
+
+    /* grab nodes corresponding to start and end and modify their class to be highlighted */
+    for (let id of range) {
+      document.getElementById(id).children[0].classList.add('active-temp');
+    }
+
+    // console.log(nodeElems);
+  }
+
+  resetActiveRegion(e) {
+
+    console.log('function');
+    console.log(e.currentTarget)
+    console.log(e.target);
+    let currActive;
+
+    if( e.currentTarget === e.target) {
+    
+      console.log('if statement');
+      currActive = document.querySelectorAll('.active-temp');
+
+      console.log(currActive);
+
+      for (let i = 0; i < currActive.length; i++) {
+        console.log('looping', i);
+        currActive[i].classList.remove('active-temp');
+
+      }
+
+      // for (let ele of currActive) {
+      //   console.log(ele);
+      // }
+    }
+
+  }
+
 
   setCurrReferent(e) {
 
     let refId = parseInt(e.currentTarget.getAttribute('refid'));
     this.setState({ activeReferentId: refId });
+
     let annotationIds = this.props.referents[refId].annotationIds[0];
-    this.props.setCurrAnnotation(annotationIds);
+
+    this.props.setCurrAnnotation(annotationIds, e.target.innerText);
 
   }
 
@@ -61,16 +134,25 @@ class SongPageLyrics extends React.Component {
 
           reconciledLyrics.push(
             <div key={Math.random() * 100000000}>
+              
               <br></br>
-              <p key={i} >{lyrics[i]}</p>
+              
+              <p id={i} key={i} >
+                <span onMouseUp={this.setActiveRegion} id={i}>{lyrics[i]}</span>
+              </p>
+
             </div>
           )
-          
+
           i++;
           
         } else {
 
-          reconciledLyrics.push( <p key={i} > {lyrics[i]}</p> ) /* lyric is not a header */
+          reconciledLyrics.push(
+            <p id={i} key={i} >
+              <span onMouseUp={this.setActiveRegion} id={i}>{lyrics[i]}</span>
+            </p> 
+          ) /* lyric is not a header */
           
           i++;
         }
@@ -92,7 +174,7 @@ class SongPageLyrics extends React.Component {
             refid={referentStartEndHash[i][1]} 
             key={Math.random() * 100000000} className={`referent ${active}`}>
 
-              {slice.map((lyric, idx) => <p key={i + idx} ><span>{lyric}</span></p>)}
+            {slice.map((lyric, idx) => <p id={i} key={i + idx} ><span onMouseUp={this.setActiveRegion} id={i}>{lyric}</span></p>)}
               
           </div>
         )
@@ -125,16 +207,15 @@ class SongPageLyrics extends React.Component {
 
     return (
       <div className="song-page-lyrics">
+
         <p className="song-page-lyrics-title">{song.title.toUpperCase()} LYRICS</p>
 
         {this.reconcileReferentsToLyrics(lyrics)}
 
       </div>
     )
-
   }
   
-
 }
 
 export default SongPageLyrics;

--- a/frontend/components/song_page_lyrics.jsx
+++ b/frontend/components/song_page_lyrics.jsx
@@ -19,11 +19,12 @@ class SongPageLyrics extends React.Component {
 
   setActiveRegion(e) {
 
+    console.log('setting active region');
+
     /* get selection particulars */
     let selection = window.getSelection();
   
-    // console.log(selection);
-
+    
     let startEleId = selection.anchorNode.parentNode.id;
     let endEleId = selection.focusNode.parentNode.id;
 
@@ -47,39 +48,37 @@ class SongPageLyrics extends React.Component {
 
     /* get range of lines from start to end */
     let range = _.range(startEleId, endEleId + 1);
-    console.log(range)
+    // console.log(range)
 
     /* grab nodes corresponding to start and end and modify their class to be highlighted */
+    let sizzle = "";
+
     for (let id of range) {
       document.getElementById(id).children[0].classList.add('active-temp');
+      sizzle.concat(document.getElementById(id).children[0].innerText, "\n");
     }
 
-    // console.log(nodeElems);
+    /* set the current annotation to -1 */
+    this.props.setCurrAnnotationStatus(-1, sizzle, true);
+ 
   }
 
   resetActiveRegion(e) {
 
-    console.log('function');
-    console.log(e.currentTarget)
-    console.log(e.target);
+    console.log('reset active region')
+
     let currActive;
 
     if( e.currentTarget === e.target) {
     
-      console.log('if statement');
       currActive = document.querySelectorAll('.active-temp');
 
-      console.log(currActive);
 
       for (let i = 0; i < currActive.length; i++) {
-        console.log('looping', i);
         currActive[i].classList.remove('active-temp');
-
       }
-
-      // for (let ele of currActive) {
-      //   console.log(ele);
-      // }
+      
+      this.props.setCurrAnnotationStatus(-1, "", false);
     }
 
   }
@@ -87,12 +86,14 @@ class SongPageLyrics extends React.Component {
 
   setCurrReferent(e) {
 
+    console.log('setting current referent')
+    
     let refId = parseInt(e.currentTarget.getAttribute('refid'));
     this.setState({ activeReferentId: refId });
 
     let annotationIds = this.props.referents[refId].annotationIds[0];
 
-    this.props.setCurrAnnotation(annotationIds, e.target.innerText);
+    this.props.setCurrAnnotationStatus(annotationIds, e.target.innerText, false);
 
   }
 
@@ -174,7 +175,7 @@ class SongPageLyrics extends React.Component {
             refid={referentStartEndHash[i][1]} 
             key={Math.random() * 100000000} className={`referent ${active}`}>
 
-            {slice.map((lyric, idx) => <p id={i} key={i + idx} ><span onMouseUp={this.setActiveRegion} id={i}>{lyric}</span></p>)}
+            {slice.map((lyric, idx) => <p id={i} key={i + idx} ><span id={i}>{lyric}</span></p>)}
               
           </div>
         )

--- a/frontend/util/referents_api_util.js
+++ b/frontend/util/referents_api_util.js
@@ -19,3 +19,14 @@ export const createReferent = referent => {
 
   })
 }
+
+export const deleteReferent = referentId => {
+
+  $.ajax({
+
+    method: "DELETE",
+    url: `api/referents/${referentId}`
+
+  })
+
+}


### PR DESCRIPTION
## Update
* Restructured SongAnnotation component to show either the 1) AboutSong text 2) Annotation or 3) Create a new Annotation form based on whether the user has: 1) Not clicked anything yet 2) Clicked an existing referent or 3) Highlighted or clicked on a song lyric which isn't a referent. New structure of the components looks something like this: 
   
```
    SongPage
        
        SongPageHeader

        SongPageAnnotation

              SongPageAnnotationDetail

                       SongPageAnnotationForm
```

* User can take path 3 to activate a region of text in preparation for a song form, or can click away to another lyric to activate another region, OR can click away from the lyrics entirely to dismiss all Song Annotation objects. 

## More to do 
* Add SongPageForm
* Add Edit and Delete buttons